### PR TITLE
Updated deployment file to be used with GitHub Actions (CLOSELOOP-T002)

### DIFF
--- a/build.docker-compose.yml
+++ b/build.docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.4"
+services:
+  api:
+    build: ./content-api
+
+  web:
+    build: ./content-web

--- a/infrastructure/deploy-infrastructure.ps1
+++ b/infrastructure/deploy-infrastructure.ps1
@@ -1,57 +1,52 @@
-#setup variables
-$studentprefix = "add"
+param
+(
+    [string] $studentprefix = "tst"
+)
+
 $resourcegroupName = "fabmedical-rg-" + $studentprefix
 $cosmosDBName = "fabmedical-cdb-" + $studentprefix
 $webappName = "fabmedical-web-" + $studentprefix
 $planName = "fabmedical-plan-" + $studentprefix
-$location1 = "westus3"
-$location2 = "eastus"
-$dbConnection = ""
-$manipulate = ""
-$dbKeys = ""
+$location1 = "westeurope"
+$location2 = "northeurope"
+$appInsights = "fabmedicalai-" + $studentsuffix
 
-#create the rss group
-az group create -l $location1 -n $resourcegroupName
+#First create a group
+$rg = az group create --name $resourcegroupName --location $location1 | ConvertFrom-Json 
 
-#create the cosmosDB
+#Then create a CosmosDB
 az cosmosdb create --name $cosmosDBName `
 --resource-group $resourcegroupName `
 --locations regionName=$location1 failoverPriority=0 isZoneRedundant=False `
 --locations regionName=$location2 failoverPriority=1 isZoneRedundant=True `
 --enable-multiple-write-locations `
---kind MongoDB `
---server-version 4.0
+--kind MongoDB
 
-#create the App Service Plan
+#Create a Azure App Service Plan
 az appservice plan create --name $planName --resource-group $resourcegroupName --sku S1 --is-linux
 
-#get and configure dbConnection string
-$dbKeys = az cosmosdb keys list -n $cosmosDBName -g $resourceGroupName --type connection-strings
-$manipulate = $dbKeys[3]
-$manipulate.Trim()
-$manipulate = $manipulate.Split("""")[3]
-$manipulate = $manipulate.Split("?")
-$dbConnection = $manipulate[0] + "contentdb?" + $manipulate[1]
+az webapp config appsettings set --settings DOCKER_REGISTRY_SERVER_URL="https://ghcr.io" --name $($webappName) --resource-group $($resourcegroupName) 
+az webapp config appsettings set --settings DOCKER_REGISTRY_SERVER_USERNAME="notapplicable" --name $($webappName) --resource-group $($resourcegroupName) 
+az webapp config appsettings set --settings DOCKER_REGISTRY_SERVER_PASSWORD="$($env:CR_PAT)" --name $($webappName) --resource-group $($resourcegroupName) 
 
-#create the WebApp with nginx
-az webapp create --resource-group $resourcegroupName `
---plan $planName --name $webappName -i nginx
 
-#configure the webapp settings
+#Create a Azure Web App with NGINX container
+az webapp create `
+--multicontainer-config-file docker-compose.yml `
+--multicontainer-config-type COMPOSE `
+--name $($webappName) `
+--resource-group $($resourcegroupName) `
+--plan $($planName)
+
 az webapp config container set `
---docker-registry-server-password $CR_PAT `
+--docker-registry-server-password $($env:CR_PAT) `
 --docker-registry-server-url https://ghcr.io `
 --docker-registry-server-user notapplicable `
---multicontainer-config-file ../docker-compose.yml `
+--multicontainer-config-file docker-compose.yml `
 --multicontainer-config-type COMPOSE `
---name $webappName `
---resource-group $resourcegroupName `
---enable-app-service-storage true
+--name $($webappName) `
+--resource-group $resourcegroupName 
 
-#set the mongoDB connection
-az webapp config appsettings set --resource-group $resourceGroupName `
---name $webappName `
---settings MONGODB_CONNECTION=$dbConnection
+az extension add --name application-insights
+az monitor app-insights component create --app $appInsights --location $location1 --kind web -g $resourcegroupName --application-type web --retention-time 120
 
-#populate the db
-docker run -ti -e MONGODB_CONNECTION=$dbConnection ghcr.io/adunn-insight/fabrikam-init


### PR DESCRIPTION

# Instructions to Fix the exercise

Modified the deployment script to have the prefix as a parameter and added the GitHub Secret environment variable instead of a local variable. To run the deployment locally, add a environment variable first that contains the GitHub Personal Access Token to pull images from the GitHub Container Registry


```PowerShell
# Personal Access Token should be pre-configured by setup.
# $env:CR_PAT="Your Pat Here" 
./infrastructure/deploy-infrastructure.ps1
```